### PR TITLE
Add single-sided note review mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@rollup/plugin-typescript": "^6.0.0",
+    "@rollup/plugin-typescript": "^8.5.0",
     "@types/node": "^14.14.41",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "prettier": "^2.2.1",

--- a/src/algorithms/anki.ts
+++ b/src/algorithms/anki.ts
@@ -1,5 +1,5 @@
 import { Setting, Notice } from "obsidian";
-import { DateUtils } from "src/utils";
+import { DateUtils } from "../utils";
 import SrsAlgorithm from "./../algorithms";
 import { RepetitionItem, ReviewResult } from "./../data";
 

--- a/src/algorithms/supermemo.ts
+++ b/src/algorithms/supermemo.ts
@@ -1,4 +1,4 @@
-import { DateUtils } from "src/utils";
+import { DateUtils } from "../utils";
 import SrsAlgorithm from "./../algorithms";
 import { RepetitionItem, ReviewResult } from "./../data";
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,6 @@
 import ObsidianSrsPlugin from "./main";
 import { ItemInfoModal } from "./modals/info";
+import { REVIEW_VIEW_TYPE } from "./view";
 
 export default class Commands {
     plugin: ObsidianSrsPlugin;
@@ -102,12 +103,14 @@ export default class Commands {
                     if (path != null) {
                         state.file = path;
                         state.item = plugin.store.getNextId();
-                        state.mode = "question";
+                        state.mode = plugin.settings.singleSidedNotes
+                            ? "single"
+                            : "question";
                     }
                 }
                 const leaf = plugin.app.workspace.getUnpinnedLeaf();
                 leaf.setViewState({
-                    type: "store-review-view",
+                    type: REVIEW_VIEW_TYPE,
                     state: state,
                 });
                 leaf.setPinned(true);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,6 @@
 import ObsidianSrsPlugin from "./main";
 import { ItemInfoModal } from "./modals/info";
+import { TrackedItemsModal } from "./modals/tracked";
 import { REVIEW_VIEW_TYPE } from "./view";
 
 export default class Commands {
@@ -88,6 +89,14 @@ export default class Commands {
             name: "Build Queue",
             callback: () => {
                 plugin.store.buildQueue();
+            },
+        });
+
+        plugin.addCommand({
+            id: "show-tracked-notes",
+            name: "Show Tracked Notes",
+            callback: () => {
+                new TrackedItemsModal(plugin).open();
             },
         });
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -5,7 +5,8 @@ import { DataLocation } from "./settings";
 import { TFile, TFolder, Notice } from "obsidian";
 
 const ROOT_DATA_PATH: string = "./tracked_files.json";
-const PLUGIN_DATA_PATH: string = "./.obsidian/plugins/obsidian-recall/tracked_files.json";
+const PLUGIN_DATA_PATH: string =
+    "./.obsidian/plugins/obsidian-recall/tracked_files.json";
 
 /**
  * SrsData.
@@ -95,6 +96,20 @@ export interface ReviewResult {
     nextReview: number;
 }
 
+export interface TrackedReviewItem {
+    itemId: number;
+    cardId: string;
+    path: string;
+    title: string;
+    nextReview: number;
+    timesReviewed: number;
+    timesCorrect: number;
+    errorStreak: number;
+    queued: boolean;
+    repeating: boolean;
+    due: boolean;
+}
+
 const DEFAULT_SRS_DATA: SrsData = {
     queue: [],
     repeatQueue: [],
@@ -154,7 +169,6 @@ export class DataStore {
         }
     }
 
-
     /**
      * moveStoreLocation.
      *
@@ -171,22 +185,26 @@ export class DataStore {
 
         try {
             this.save();
-            adapter.remove(this.dataPath).then(() => {
-                this.dataPath = newPath;
-                new Notice("Successfully moved data file!");
-                return true;
-            }, (e) => {
-                this.dataPath = newPath;
-                new Notice("Unable to delete old data file, please delete it manually.");
-                console.log(e);
-                return true;
-            })
+            adapter.remove(this.dataPath).then(
+                () => {
+                    this.dataPath = newPath;
+                    new Notice("Successfully moved data file!");
+                    return true;
+                },
+                (e) => {
+                    this.dataPath = newPath;
+                    new Notice(
+                        "Unable to delete old data file, please delete it manually."
+                    );
+                    console.log(e);
+                    return true;
+                }
+            );
         } catch (e) {
             new Notice("Unable to move data file!");
             console.log(e);
             return false;
         }
-
     }
 
     /**
@@ -345,7 +363,58 @@ export class DataStore {
             return this.data.trackedFiles[item.fileIndex];
         }
         return null;
-    } 
+    }
+
+    getTrackedReviewItems(): TrackedReviewItem[] {
+        const now = new Date().getTime();
+        let result: TrackedReviewItem[] = [];
+
+        this.data.trackedFiles.forEach((file) => {
+            if (file == null) {
+                return;
+            }
+
+            for (let cardId in file.items) {
+                const itemId = file.items[cardId];
+                const item = this.data.items[itemId];
+                if (item == null) {
+                    continue;
+                }
+
+                result.push({
+                    itemId,
+                    cardId,
+                    path: file.path,
+                    title: this.getTitleFromPath(file.path),
+                    nextReview: item.nextReview,
+                    timesReviewed: item.timesReviewed,
+                    timesCorrect: item.timesCorrect,
+                    errorStreak: item.errorStreak,
+                    queued: this.isQueued(itemId),
+                    repeating: this.isInRepeatQueue(itemId),
+                    due: item.nextReview == 0 || item.nextReview <= now,
+                });
+            }
+        });
+
+        return result.sort((a, b) => {
+            if (a.due != b.due) {
+                return a.due ? -1 : 1;
+            }
+
+            if (a.nextReview != b.nextReview) {
+                return a.nextReview - b.nextReview;
+            }
+
+            return a.title.localeCompare(b.title);
+        });
+    }
+
+    getTitleFromPath(path: string): string {
+        const parts = path.split("/");
+        const name = parts[parts.length - 1] || path;
+        return name.replace(/\.md$/i, "");
+    }
 
     /**
      * getNext.
@@ -676,37 +745,38 @@ export class DataStore {
 
         let untrackedFiles = 0;
         let removedItems = 0;
-        
-        await Promise.all(this.data.items.map((item, id) => {
-            if (item != null) {
-                let file = this.getFileForItem(item);
-                return this.verify(file).then((exists) => {
-                    if (!exists) {
-                        removedItems += this.untrackFile(file.path, false);
-                        untrackedFiles += 1;
-                    }
-                    else {
-                        if (item.nextReview == 0) {
-                            // This is a new item.
-                            if (maxNew == -1 || data.newAdded < maxNew) {
-                                item.nextReview = now.getTime();
-                                data.newAdded += 1;
-                                data.queue.push(id);
-                                newAdd += 1;
-                            }
-                        } else if (item.nextReview <= now.getTime()) {
-                            if (this.isInRepeatQueue(id)) {
-                                data.repeatQueue.remove(id);
-                            }
-                            if (!this.isQueued(id)) {
-                                data.queue.push(id);
-                                oldAdd += 1;
+
+        await Promise.all(
+            this.data.items.map((item, id) => {
+                if (item != null) {
+                    let file = this.getFileForItem(item);
+                    return this.verify(file).then((exists) => {
+                        if (!exists) {
+                            removedItems += this.untrackFile(file.path, false);
+                            untrackedFiles += 1;
+                        } else {
+                            if (item.nextReview == 0) {
+                                // This is a new item.
+                                if (maxNew == -1 || data.newAdded < maxNew) {
+                                    item.nextReview = now.getTime();
+                                    data.newAdded += 1;
+                                    data.queue.push(id);
+                                    newAdd += 1;
+                                }
+                            } else if (item.nextReview <= now.getTime()) {
+                                if (this.isInRepeatQueue(id)) {
+                                    data.repeatQueue.remove(id);
+                                }
+                                if (!this.isQueued(id)) {
+                                    data.queue.push(id);
+                                    oldAdd += 1;
+                                }
                             }
                         }
-                    }
-                });
-            }
-        }));
+                    });
+                }
+            })
+        );
 
         this.data.lastQueue = now.getTime();
         if (this.plugin.settings.shuffleQueue && oldAdd + newAdd > 0) {
@@ -720,9 +790,15 @@ export class DataStore {
                 newAdd +
                 " new!"
         );
-        
+
         if (untrackedFiles > 0) {
-            new Notice("Recall: Untracked " + untrackedFiles + " files with a total of " + removedItems + " items while building queue!");
+            new Notice(
+                "Recall: Untracked " +
+                    untrackedFiles +
+                    " files with a total of " +
+                    removedItems +
+                    " items while building queue!"
+            );
         }
     }
 
@@ -734,12 +810,10 @@ export class DataStore {
     verify(file: TrackedFile): Promise<boolean> {
         const adapter = this.plugin.app.vault.adapter;
         if (file != null) {
-            return adapter.exists(file.path).catch(
-                (reason) => {
-                    console.error("Unable to verify file: ", file.path);
-                    return false;
-                }
-            );
+            return adapter.exists(file.path).catch((reason) => {
+                console.error("Unable to verify file: ", file.path);
+                return false;
+            });
         }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import { TFolder, TFile, Plugin } from "obsidian";
 import { DataStore } from "./data";
-import { ReviewView } from "./view";
+import { REVIEW_VIEW_TYPE, ReviewView } from "./view";
 import SrsAlgorithm from "./algorithms";
 import SrsSettingTab from "./settings";
 import { SrsPluginSettings, DEFAULT_SETTINGS, algorithms } from "./settings";
 import Commands from "./commands";
-import { ItemSelector, SelectorType } from './selection';
+import { ItemSelector, SelectorType } from "./selection";
 
 const DEBUG: boolean = true;
 
@@ -44,7 +44,7 @@ export default class ObsidianSrsPlugin extends Plugin {
 
         this.registerEvents();
 
-        this.registerView("store-review-view", (leaf) => {
+        this.registerView(REVIEW_VIEW_TYPE, (leaf) => {
             return new ReviewView(leaf, this);
         });
 

--- a/src/modals/info.ts
+++ b/src/modals/info.ts
@@ -1,5 +1,5 @@
 import { Modal, TFile } from "obsidian";
-import ObsidianSrsPlugin from "src/main";
+import ObsidianSrsPlugin from "../main";
 import { DataStore } from "../data";
 
 export class ItemInfoModal extends Modal {

--- a/src/modals/tracked.ts
+++ b/src/modals/tracked.ts
@@ -1,0 +1,137 @@
+import { ButtonComponent, Modal, TFile } from "obsidian";
+import ObsidianSrsPlugin from "../main";
+import { TrackedReviewItem } from "../data";
+
+export class TrackedItemsModal extends Modal {
+    plugin: ObsidianSrsPlugin;
+
+    constructor(plugin: ObsidianSrsPlugin) {
+        super(plugin.app);
+        this.plugin = plugin;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        const items = this.plugin.store.getTrackedReviewItems();
+
+        contentEl.empty();
+        contentEl.addClass("srs-tracked-modal");
+        contentEl.createEl("h2", { text: "Tracked Notes" });
+
+        if (items.length == 0) {
+            contentEl.createEl("p", {
+                text: "No notes are currently tracked.",
+            });
+            return;
+        }
+
+        const summary = contentEl.createDiv("srs-tracked-summary");
+        summary.setText(
+            items.length +
+                " tracked " +
+                (items.length == 1 ? "card" : "cards") +
+                ", " +
+                items.filter((item) => item.due).length +
+                " due"
+        );
+
+        const list = contentEl.createDiv("srs-tracked-list");
+        items.forEach((item) => this.addItemRow(list, item));
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.removeClass("srs-tracked-modal");
+    }
+
+    private addItemRow(containerEl: HTMLElement, item: TrackedReviewItem) {
+        const row = containerEl.createDiv("srs-tracked-item");
+
+        const main = row.createDiv("srs-tracked-item-main");
+        const title = main.createDiv("srs-tracked-title");
+        title.setText(item.title);
+
+        const path = main.createDiv("srs-tracked-path");
+        path.setText(item.path);
+
+        const meta = main.createDiv("srs-tracked-meta");
+        meta.createSpan({
+            text: this.formatReviewState(item),
+            cls: item.due ? "srs-tracked-due" : "srs-tracked-not-due",
+        });
+        meta.createSpan({ text: this.formatStats(item) });
+
+        const actions = row.createDiv("srs-tracked-actions");
+        new ButtonComponent(actions)
+            .setButtonText("Open")
+            .onClick(() => this.openItem(item));
+    }
+
+    private openItem(item: TrackedReviewItem) {
+        const file = this.app.vault.getAbstractFileByPath(item.path);
+        if (!(file instanceof TFile)) {
+            return;
+        }
+
+        const leaf = this.app.workspace.getUnpinnedLeaf();
+        leaf.setViewState({
+            type: "markdown",
+            state: {
+                file: file.path,
+            },
+        });
+        this.app.workspace.setActiveLeaf(leaf);
+        this.close();
+    }
+
+    private formatReviewState(item: TrackedReviewItem): string {
+        if (item.repeating) {
+            return "Repeat queue";
+        }
+
+        if (item.nextReview == 0) {
+            return "New";
+        }
+
+        if (item.due) {
+            return "Due now";
+        }
+
+        return "Next: " + this.formatRelativeTime(item.nextReview);
+    }
+
+    private formatStats(item: TrackedReviewItem): string {
+        if (item.timesReviewed == 0) {
+            return "Not reviewed yet";
+        }
+
+        return (
+            item.timesCorrect +
+            "/" +
+            item.timesReviewed +
+            " correct, streak " +
+            item.errorStreak
+        );
+    }
+
+    private formatRelativeTime(timestamp: number): string {
+        const diffMs = timestamp - new Date().getTime();
+        const absMs = Math.abs(diffMs);
+        const hourMs = 1000 * 60 * 60;
+        const dayMs = hourMs * 24;
+
+        if (absMs < hourMs) {
+            const minutes = Math.max(1, Math.round(absMs / (1000 * 60)));
+            return diffMs >= 0 ? "in " + minutes + "m" : minutes + "m ago";
+        }
+
+        if (absMs < dayMs) {
+            const hours = Math.round(absMs / hourMs);
+            return diffMs >= 0 ? "in " + hours + "h" : hours + "h ago";
+        }
+
+        const days = Math.round(absMs / dayMs);
+        return diffMs >= 0 ? "in " + days + "d" : days + "d ago";
+    }
+}

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,9 +1,9 @@
-import {Loc, Pos, SectionCache, CachedMetadata, Notice} from 'obsidian';
-import { BlockUtils, MiscUtils } from './utils';
+import { Loc, Pos, SectionCache, CachedMetadata, Notice } from "obsidian";
+import { BlockUtils, MiscUtils } from "./utils";
 
 export interface IdInsert {
-    id: string,
-    pos: Loc
+    id: string;
+    pos: Loc;
 }
 
 export interface ItemContent {
@@ -17,56 +17,69 @@ export enum SelectorType {
     SeparateRegExp,
     NextBlock,
     Until,
-    UntilNot
+    UntilNot,
 }
 
-type BlockType = 'paragraph' | 'heading' | 'yaml' | 'thematicBreak' | 'list' | 'blockquote' | 'code';
+type BlockType =
+    | "paragraph"
+    | "heading"
+    | "yaml"
+    | "thematicBreak"
+    | "list"
+    | "blockquote"
+    | "code";
 
 type SplitData = {
     selectorType: SelectorType.Split;
     markerBlocks: BlockType[];
     splitString: string;
-}
+};
 
 type SingleRegExpData = {
     selectorType: SelectorType.SingleRegExp;
     markerBlocks: BlockType[];
-    regExp: RegExp;
-}
+    qaRegExp: RegExp;
+};
 
 type SeparateRegExpData = {
     selectorType: SelectorType.SeparateRegExp;
     markerBlocks: BlockType[];
     questionRegExp: RegExp;
     answerRegExp: RegExp;
-}
+};
 
 type NextBlockData = {
     selectorType: SelectorType.NextBlock;
     markerBlocks: BlockType[];
-}
+};
 
 type UntilData = {
     selectorType: SelectorType.Until;
     markerBlocks: BlockType[];
     answerBlocks: BlockType[];
-}
+};
 
 type UntilNotData = {
     selectorType: SelectorType.UntilNot;
     markerBlocks: BlockType[];
     answerBlocks: BlockType[];
-}
+};
 
 type SingleBlockData = SplitData | SingleRegExpData | SeparateRegExpData;
 type MultipleBlocksData = NextBlockData | UntilData | UntilNotData;
 type SelectorData = SingleBlockData | MultipleBlocksData;
 
-type ProcessorResult = {item: ItemContent, usedSections: number[] } | null;
-type Processor = (data: SelectorData, index: number, s: SectionCache[], content: string, metadata: CachedMetadata) => ProcessorResult;
+type ProcessorResult = { item: ItemContent; usedSections: number[] } | null;
+type Processor = (
+    data: SelectorData,
+    index: number,
+    s: SectionCache[],
+    content: string,
+    metadata: CachedMetadata
+) => ProcessorResult;
+type SectionWithId = SectionCache & { id?: string };
 
 export class ItemSelector {
-
     private data: SelectorData;
     private processors: Record<SelectorType, Processor> = {
         [SelectorType.NextBlock]: processNextBlock,
@@ -78,38 +91,60 @@ export class ItemSelector {
     };
 
     constructor() {
-        this.data = <NextBlockData> {
-            markerBlocks: ['heading']
+        this.data = <NextBlockData>{
+            selectorType: SelectorType.NextBlock,
+            markerBlocks: ["heading"],
         };
     }
 
-    public process(sections: SectionCache[], inserts: IdInsert[], content: string, metadata: CachedMetadata): Record<string, ItemContent> {
+    public process(
+        sections: SectionCache[],
+        inserts: IdInsert[],
+        content: string,
+        metadata: CachedMetadata
+    ): Record<string, ItemContent> {
         // Write general logic here, rename question/matched blocks to marker blocks
         // and let processors handle each detection.
         let items: Record<string, ItemContent> = {};
         let usedSections: number[] = [];
 
-        for (let i = 0; i < sections.length; i++) { 
+        for (let i = 0; i < sections.length; i++) {
             let section: SectionCache = sections[i];
 
             if (this.data.markerBlocks.contains(<BlockType>section.type)) {
-                let result = this.processors[this.data.selectorType](this.data, sections, content, metadata);
+                let result = this.processors[this.data.selectorType](
+                    this.data,
+                    i,
+                    sections,
+                    content,
+                    metadata
+                );
                 if (result != null) {
+                    let id = (<SectionWithId>section).id;
+                    if (id === undefined) {
+                        id = BlockUtils.generateBlockId();
+                        inserts.push({ id: id, pos: section.position.end });
+                    }
+                    items[id] = result.item;
+                    usedSections = usedSections.concat(result.usedSections);
                     i = result.usedSections.sort((a, b) => b - a)[0];
                 }
             }
         }
 
-        usedSections.sort((a, b) => b - a);
+        usedSections = Array.from(new Set(usedSections)).sort((a, b) => b - a);
         usedSections.forEach((i) => sections.splice(i, 1));
-        
+
         return items;
     }
 
-    public processSingle(sections: SectionCache[], inserts: IdInsert[], content: string, metadata: CachedMetadata): Record<string, ItemContent> {
-
-        
-        
+    public processSingle(
+        sections: SectionCache[],
+        inserts: IdInsert[],
+        content: string,
+        metadata: CachedMetadata
+    ): Record<string, ItemContent> {
+        return {};
     }
 }
 /*
@@ -220,36 +255,55 @@ export class SingleBlockSelector extends ItemSelector {
 }
 */
 
-function processNextBlock(rawData: SelectorData, index: number, sections: SectionCache[], content: string, metadata: CachedMetadata): ProcessorResult {
-
+function processNextBlock(
+    rawData: SelectorData,
+    index: number,
+    sections: SectionCache[],
+    content: string,
+    metadata: CachedMetadata
+): ProcessorResult {
     let data: NextBlockData = <NextBlockData>rawData;
     let section = sections[index];
     let usedSections: number[] = [index, index + 1];
-    let questionContent = content.slice(section.position.start.offset, section.position.end.offset);
+    let questionContent = content.slice(
+        section.position.start.offset,
+        section.position.end.offset
+    );
 
     if (index + 1 < sections.length) {
         let nextBlock = sections[index + 1];
-        let answerContent = content.slice(nextBlock.position.start.offset, nextBlock.position.end.offset);
+        let answerContent = content.slice(
+            nextBlock.position.start.offset,
+            nextBlock.position.end.offset
+        );
 
         let itemContent = {
             question: questionContent,
-            answer: answerContent
+            answer: answerContent,
         };
-        
+
         return {
             item: itemContent,
-            usedSections: usedSections
-        }
+            usedSections: usedSections,
+        };
     }
 
     return null;
 }
 
-function processUntil(rawData: SelectorData, index: number, sections: SectionCache[], content: string, metadata: CachedMetadata): ProcessorResult {
-
+function processUntil(
+    rawData: SelectorData,
+    index: number,
+    sections: SectionCache[],
+    content: string,
+    metadata: CachedMetadata
+): ProcessorResult {
     let data: UntilData = <UntilData>rawData;
     let section = sections[index];
-    let questionContent = content.slice(section.position.start.offset, section.position.end.offset);
+    let questionContent = content.slice(
+        section.position.start.offset,
+        section.position.end.offset
+    );
 
     let start: Loc | null = null;
     let end: Loc | null = null;
@@ -258,8 +312,7 @@ function processUntil(rawData: SelectorData, index: number, sections: SectionCac
         let block = sections[j];
         if (data.answerBlocks.contains(<BlockType>block.type)) {
             break;
-        }
-        else {
+        } else {
             if (start === null) {
                 start = block.position.start;
             }
@@ -273,23 +326,31 @@ function processUntil(rawData: SelectorData, index: number, sections: SectionCac
 
         let itemContent = {
             question: questionContent,
-            answer: answerContent
+            answer: answerContent,
         };
-        
+
         return {
             item: itemContent,
             usedSections: used,
-        }
+        };
     }
 
     return null;
 }
 
-function processUntilNot(rawData: SelectorData, index: number, sections: SectionCache[], content: string, metadata: CachedMetadata): ProcessorResult {
-
+function processUntilNot(
+    rawData: SelectorData,
+    index: number,
+    sections: SectionCache[],
+    content: string,
+    metadata: CachedMetadata
+): ProcessorResult {
     let data: UntilNotData = <UntilNotData>rawData;
     let section = sections[index];
-    let questionContent = content.slice(section.position.start.offset, section.position.end.offset);
+    let questionContent = content.slice(
+        section.position.start.offset,
+        section.position.end.offset
+    );
 
     let start: Loc | null = null;
     let end: Loc | null = null;
@@ -298,8 +359,7 @@ function processUntilNot(rawData: SelectorData, index: number, sections: Section
         let block = sections[j];
         if (!data.answerBlocks.contains(<BlockType>block.type)) {
             break;
-        }
-        else {
+        } else {
             if (start === null) {
                 start = block.position.start;
             }
@@ -313,105 +373,98 @@ function processUntilNot(rawData: SelectorData, index: number, sections: Section
 
         let itemContent = {
             question: questionContent,
-            answer: answerContent
+            answer: answerContent,
         };
-        
+
         return {
             item: itemContent,
             usedSections: used,
-        }
+        };
     }
 
     return null;
 }
 
-function processSplit(rawData: SelectorData, sections: SectionCache[], inserts: IdInsert[], content: string, metadata: CachedMetadata): Record<string, ItemContent> {
+function processSplit(
+    rawData: SelectorData,
+    index: number,
+    sections: SectionCache[],
+    content: string,
+    metadata: CachedMetadata
+): ProcessorResult {
     let data: SplitData = <SplitData>rawData;
-    let items: Record<string, ItemContent> = {};
-    let usedSections: number[] = [];
+    let section = sections[index];
+    let sectionContent = content.slice(
+        section.position.start.offset,
+        section.position.end.offset
+    );
+    let split = sectionContent.split(data.splitString, 2);
 
-    for (let i = 0; i < sections.length; i++) { 
-        let section: SectionCache = sections[i];
-
-        if (data.markerBlocks.contains(<BlockType>section.type)) {
-            let sectionContent = content.slice(section.position.start.offset, section.position.end.offset);
-            let split = sectionContent.split(data.splitString, 2);
-            if (split.length == 2) {
-                let itemContent = {
-                    question: split[0],
-                    answer: split[1]
-                }
-
-                let id = section.id;
-                if (id === undefined) {
-                    id = BlockUtils.generateBlockId();
-                    inserts.push({id: id, pos: section.position.end});
-                }
-                items[id] = itemContent;
-                usedSections.push(i);
-            }
-        }
+    if (split.length == 2) {
+        return {
+            item: {
+                question: split[0],
+                answer: split[1],
+            },
+            usedSections: [index],
+        };
     }
 
-    return {} // TODO
+    return null;
 }
 
-function processSeparateRegExp(rawData: SelectorData, sections: SectionCache[], inserts: IdInsert[], content: string, metadata: CachedMetadata): Record<string, ItemContent> {
+function processSeparateRegExp(
+    rawData: SelectorData,
+    index: number,
+    sections: SectionCache[],
+    content: string,
+    metadata: CachedMetadata
+): ProcessorResult {
     let data: SeparateRegExpData = <SeparateRegExpData>rawData;
-    let items: Record<string, ItemContent> = {};
-    let usedSections: number[] = [];
+    let section = sections[index];
+    let sectionContent = content.slice(
+        section.position.start.offset,
+        section.position.end.offset
+    );
 
-    for (let i = 0; i < sections.length; i++) { 
-        let section: SectionCache = sections[i];
+    let questionMatch = sectionContent.match(data.questionRegExp);
+    let answerMatch = sectionContent.match(data.answerRegExp);
+    if (questionMatch !== null && answerMatch !== null) {
+        return {
+            item: {
+                question: questionMatch[1],
+                answer: answerMatch[1],
+            },
+            usedSections: [index],
+        };
+    }
 
-        if (data.markerBlocks.contains(<BlockType>section.type)) {
-            let sectionContent = content.slice(section.position.start.offset, section.position.end.offset);
-
-            let questionMatch = sectionContent.match(data.questionRegExp);
-            let answerMatch = sectionContent.match(data.answerRegExp);
-            if (questionMatch !== null && answerMatch !== null) {
-                let itemContent = {
-                    question: questionMatch[1],
-                    answer: answerMatch[1],
-                }
-
-                let id = section.id;
-                if (id === undefined) {
-                    id = BlockUtils.generateBlockId();
-                    inserts.push({id: id, pos: section.position.end});
-                }
-                items[id] = itemContent;
-                usedSections.push(i);
-            }
-
-    return {} // TODO
+    return null;
 }
 
-function processSingleRegExp(rawData: SelectorData, sections: SectionCache[], inserts: IdInsert[], content: string, metadata: CachedMetadata): Record<string, ItemContent> {
+function processSingleRegExp(
+    rawData: SelectorData,
+    index: number,
+    sections: SectionCache[],
+    content: string,
+    metadata: CachedMetadata
+): ProcessorResult {
     let data: SingleRegExpData = <SingleRegExpData>rawData;
-    let items: Record<string, ItemContent> = {};
-    let usedSections: number[] = [];
+    let section = sections[index];
+    let sectionContent = content.slice(
+        section.position.start.offset,
+        section.position.end.offset
+    );
+    let match = sectionContent.match(data.qaRegExp);
+    if (match !== null) {
+        return {
+            item: {
+                question: match[1],
+                answer: match[2],
+            },
+            usedSections: [index],
+        };
+    }
 
-    for (let i = 0; i < sections.length; i++) { 
-        let section: SectionCache = sections[i];
-
-        if (data.markerBlocks.contains(<BlockType>section.type)) {
-            let sectionContent = content.slice(section.position.start.offset, section.position.end.offset);
-            let match = sectionContent.match(data.qaRegExp);
-            if (match !== null) {
-                let itemContent = {
-                    question: match[1],
-                    answer: match[2],
-                }
-
-                let id = section.id;
-                if (id === undefined) {
-                    id = BlockUtils.generateBlockId();
-                    inserts.push({id: id, pos: section.position.end});
-                }
-                items[id] = itemContent;
-                usedSections.push(i);
-            }
-
-    return {} // TODO
+    return null;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,12 @@
-import { Modal, App, Setting, Notice, PluginSettingTab, ButtonComponent, DropdownComponent } from "obsidian";
+import {
+    Modal,
+    App,
+    Setting,
+    Notice,
+    PluginSettingTab,
+    ButtonComponent,
+    DropdownComponent,
+} from "obsidian";
 import ObsidianSrsPlugin from "./main";
 
 import SrsAlgorithm from "./algorithms";
@@ -17,7 +25,7 @@ export const algorithms: Record<string, SrsAlgorithm> = {
 
 export enum DataLocation {
     PluginFolder = "In Plugin Folder",
-    RootFolder = "In Vault Folder"
+    RootFolder = "In Vault Folder",
 }
 
 const locationMap: Record<string, DataLocation> = {
@@ -25,11 +33,11 @@ const locationMap: Record<string, DataLocation> = {
     "In Plugin Folder": DataLocation.PluginFolder,
 };
 
-
 export interface SrsPluginSettings {
     maxNewPerDay: number;
     repeatItems: boolean;
     shuffleQueue: boolean;
+    singleSidedNotes: boolean;
     dataLocation: DataLocation;
     locationPath: string;
     algorithm: string;
@@ -41,6 +49,7 @@ export const DEFAULT_SETTINGS: SrsPluginSettings = {
     maxNewPerDay: 20,
     repeatItems: true,
     shuffleQueue: true,
+    singleSidedNotes: false,
     dataLocation: DataLocation.RootFolder,
     locationPath: "",
     algorithm: Object.keys(algorithms)[0],
@@ -65,6 +74,7 @@ export default class SrsSettingTab extends PluginSettingTab {
         this.addNewPerDaySetting(containerEl);
         this.addRepeatItemsSetting(containerEl);
         this.addShuffleSetting(containerEl);
+        this.addSingleSidedNotesSetting(containerEl);
         this.addDataLocationSettings(containerEl);
         this.addItemSelectionSetting(containerEl);
         this.addAlgorithmSetting(containerEl);
@@ -83,11 +93,13 @@ export default class SrsSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName("Data Location")
-            .setDesc("Where to store the data file for spaced repetition items.")
+            .setDesc(
+                "Where to store the data file for spaced repetition items."
+            )
             .addDropdown((dropdown) => {
                 Object.values(DataLocation).forEach((val) => {
                     dropdown.addOption(val, val);
-                })
+                });
                 dropdown.setValue(plugin.settings.dataLocation);
 
                 dropdown.onChange((val) => {
@@ -188,13 +200,33 @@ export default class SrsSettingTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName("Shuffle Queue")
             .setDesc(
-                "Whether or not the review queue order should be shuffled. If not the queue is in the order the items where added to the SRS.")
+                "Whether or not the review queue order should be shuffled. If not the queue is in the order the items where added to the SRS."
+            )
             .addToggle((toggle) => {
-                toggle.setValue(plugin.settings.shuffleQueue)
-                .onChange((newValue) => {
-                    plugin.settings.shuffleQueue = newValue;
-                    plugin.saveData(plugin.settings);
-                })
+                toggle
+                    .setValue(plugin.settings.shuffleQueue)
+                    .onChange((newValue) => {
+                        plugin.settings.shuffleQueue = newValue;
+                        plugin.saveData(plugin.settings);
+                    });
+            });
+    }
+
+    addSingleSidedNotesSetting(containerEl: HTMLElement) {
+        const plugin = this.plugin;
+
+        new Setting(containerEl)
+            .setName("Single-sided notes")
+            .setDesc(
+                "Show the full note during review and grade it immediately, instead of showing a question first and revealing an answer."
+            )
+            .addToggle((toggle) => {
+                toggle
+                    .setValue(plugin.settings.singleSidedNotes)
+                    .onChange((newValue) => {
+                        plugin.settings.singleSidedNotes = newValue;
+                        plugin.saveData(plugin.settings);
+                    });
             });
     }
 
@@ -224,34 +256,32 @@ class ItemSettingsModal extends Modal {
     }
 
     onOpen() {
-        let {titleEl, contentEl, plugin} = this;
+        let { titleEl, contentEl, plugin } = this;
 
         titleEl.createEl("h3").innerText = "Selector Settings";
 
         // TODO: Show all item selector settings
-        this.selectorList = new Array<SelectorSettings>(plugin.settings.itemSelectors.length);
+        this.selectorList = new Array<SelectorSettings>(
+            plugin.settings.itemSelectors.length
+        );
         plugin.settings.itemSelectors.forEach((selector, i) => {
             this.selectorList[i] = new SelectorSettings(contentEl, selector);
         });
 
         // TODO: Add button for adding item selector
-        new ButtonComponent(contentEl)
-            .setButtonText("Add Selector")
-            .setCta();
+        new ButtonComponent(contentEl).setButtonText("Add Selector").setCta();
 
         // TODO: Default behavior
     }
 
     onClose() {
-        let {titleEl, contentEl} = this;
+        let { titleEl, contentEl } = this;
         contentEl.empty();
         titleEl.empty();
     }
-
 }
 
 class SelectorSettings {
-
     private parentEl: HTMLElement;
     private selector: ItemSelector;
     private mainDiv: HTMLDivElement;
@@ -259,22 +289,22 @@ class SelectorSettings {
     constructor(containerEl: HTMLElement, selector: ItemSelector) {
         this.parentEl = containerEl;
         this.selector = selector;
-        this.mainDiv = this.parentEl.createDiv('selector-settings-div');
+        this.mainDiv = this.parentEl.createDiv("selector-settings-div");
         this.build();
     }
 
     private build() {
-        let {mainDiv} = this;
+        let { mainDiv } = this;
 
         mainDiv.empty();
 
-        let paragraph = mainDiv.createEl('p');
+        let paragraph = mainDiv.createEl("p");
         paragraph.innerText = "Select ";
 
         let selectorTypes: Record<string, SelectorType> = {
-            "a single block": SelectorType.SingleBlock,
-            "multiple blocks": SelectorType.MultipleBlocks,
-        }
+            "a single block": SelectorType.Split,
+            "multiple blocks": SelectorType.NextBlock,
+        };
 
         let dropdown = new DropdownComponent(mainDiv);
         for (let key in selectorTypes) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -7,9 +7,43 @@ import {
     TFile,
 } from "obsidian";
 import ObsidianSrsPlugin from "./main";
-import { IdInsert, ItemContent } from './selection';
+import { IdInsert, ItemContent } from "./selection";
 
-export type ReviewMode = "question" | "answer" | "empty";
+export const REVIEW_VIEW_TYPE = "store-review-view";
+export type ReviewMode = "question" | "answer" | "single" | "empty";
+
+function getStartReviewMode(plugin: ObsidianSrsPlugin): ReviewMode {
+    return plugin.settings.singleSidedNotes ? "single" : "question";
+}
+
+function openFile(view: ReviewView) {
+    const leaf = view.app.workspace.getUnpinnedLeaf();
+    leaf.setViewState({
+        type: "markdown",
+        state: {
+            file: view.file.path,
+        },
+    });
+    view.app.workspace.setActiveLeaf(leaf);
+}
+
+function reviewItem(view: ReviewView, option: string) {
+    view.plugin.store.reviewId(view.item, option);
+    const item = view.plugin.store.getNext();
+    const state: any = { mode: "empty" };
+    if (item != null) {
+        const path = view.plugin.store.getFilePath(item);
+        if (path != null) {
+            state.file = path;
+            state.item = view.plugin.store.getNextId();
+            state.mode = getStartReviewMode(view.plugin);
+        }
+    }
+    view.leaf.setViewState({
+        type: REVIEW_VIEW_TYPE,
+        state: state,
+    });
+}
 
 export class ReviewView extends FileView {
     plugin: ObsidianSrsPlugin;
@@ -18,6 +52,7 @@ export class ReviewView extends FileView {
 
     questionSubView: ReviewQuestionView;
     answerSubView: ReviewAnswerView;
+    singleSidedSubView: ReviewSingleSidedView;
     emptySubView: ReviewEmptyView;
 
     currentSubView: ReviewSubView;
@@ -36,6 +71,7 @@ export class ReviewView extends FileView {
 
         this.questionSubView = new ReviewQuestionView(this);
         this.answerSubView = new ReviewAnswerView(this);
+        this.singleSidedSubView = new ReviewSingleSidedView(this);
         this.emptySubView = new ReviewEmptyView(this);
 
         this.currentSubView = this.emptySubView;
@@ -65,6 +101,9 @@ export class ReviewView extends FileView {
         } else if (this.mode == "answer") {
             this.currentSubView = this.answerSubView;
             this.currentSubView.show();
+        } else if (this.mode == "single") {
+            this.currentSubView = this.singleSidedSubView;
+            this.currentSubView.show();
         }
 
         console.log("Loading item " + this.item + "...");
@@ -74,22 +113,33 @@ export class ReviewView extends FileView {
                 console.log(content);
                 let question: string = this.file.basename;
                 let answer: string = content.trim();
+                let fullContent: string = content.trim();
                 const metadata = this.app.metadataCache.getFileCache(this.file);
 
                 if (metadata) {
                     if (metadata.sections) {
-
                         let sections = [...metadata.sections];
                         let idInserts: IdInsert[] = [];
                         let items: Record<string, ItemContent> = {};
-                        this.plugin.settings.itemSelectors.forEach((selector) => {
-                            let newItems = selector.process(sections, idInserts, content, metadata);
-                            items = {...items, ...newItems};
-                        });
+                        this.plugin.settings.itemSelectors.forEach(
+                            (selector) => {
+                                let newItems = selector.process(
+                                    sections,
+                                    idInserts,
+                                    content,
+                                    metadata
+                                );
+                                items = { ...items, ...newItems };
+                            }
+                        );
 
                         console.log(sections);
                         console.log(idInserts);
-                        console.log("Found ", Object.keys(items).length, " items!");
+                        console.log(
+                            "Found ",
+                            Object.keys(items).length,
+                            " items!"
+                        );
                         console.log(items);
 
                         //let selector = new SingleBlockSelector();
@@ -119,7 +169,12 @@ export class ReviewView extends FileView {
                             .trim();
                     }
                 }
-                this.currentSubView.set(question, answer, this.file);
+                this.currentSubView.set(
+                    question,
+                    answer,
+                    this.file,
+                    fullContent
+                );
             },
             (err) => {
                 console.log("Unable to read item: " + err);
@@ -134,12 +189,17 @@ export class ReviewView extends FileView {
     }
 
     getViewType(): string {
-        return "srs-review-view";
+        return REVIEW_VIEW_TYPE;
     }
 }
 
 export interface ReviewSubView {
-    set(question: string, answer: string, file: TFile): void;
+    set(
+        question: string,
+        answer: string,
+        file: TFile,
+        fullContent: string
+    ): void;
 
     show(): void;
     hide(): void;
@@ -155,7 +215,7 @@ export class ReviewEmptyView implements ReviewSubView {
         this.containerEl.innerText = "Your queue is empty!";
     }
 
-    set(question: string, answer: string, file: TFile) {}
+    set(question: string, answer: string, file: TFile, fullContent: string) {}
 
     show() {
         this.containerEl.hidden = false;
@@ -174,7 +234,7 @@ export class ReviewQuestionView implements ReviewSubView {
     constructor(view: ReviewView) {
         let answerClick = (view: ReviewView) => {
             view.leaf.setViewState({
-                type: "srs-review-view",
+                type: REVIEW_VIEW_TYPE,
                 state: {
                     file: view.file.path,
                     mode: "answer",
@@ -213,7 +273,7 @@ export class ReviewQuestionView implements ReviewSubView {
             .setClass("srs-review-button");
     }
 
-    set(question: string, answer: string, file: TFile) {
+    set(question: string, answer: string, file: TFile, fullContent: string) {
         this.questionEl.empty();
 
         MarkdownRenderer.renderMarkdown(
@@ -241,27 +301,10 @@ export class ReviewAnswerView implements ReviewSubView {
     buttons: ButtonComponent[];
 
     constructor(view: ReviewView) {
-        let buttonClick = (view: ReviewView, s: string) => {
-            view.plugin.store.reviewId(view.item, s);
-            const item = view.plugin.store.getNext();
-            const state: any = { mode: "empty" };
-            if (item != null) {
-                const path = view.plugin.store.getFilePath(item);
-                if (path != null) {
-                    state.file = path;
-                    state.item = view.plugin.store.getNextId();
-                    state.mode = "question";
-                }
-            }
-            view.leaf.setViewState({
-                type: "srs-review-view",
-                state: state,
-            });
-        };
         this.containerEl = view.wrapperEl.createDiv("srs-review-answer");
         this.containerEl.hidden = true;
 
-        let wrapperEl = this.containerEl.createDiv('srs-qa-wrapper');
+        let wrapperEl = this.containerEl.createDiv("srs-qa-wrapper");
 
         this.questionEl = wrapperEl.createDiv("srs-question-content");
         this.answerEl = wrapperEl.createDiv("srs-answer-content");
@@ -277,7 +320,7 @@ export class ReviewAnswerView implements ReviewSubView {
                 new ButtonComponent(buttonRow)
                     .setButtonText(s)
                     .setCta()
-                    .onClick(() => buttonClick(view, s))
+                    .onClick(() => reviewItem(view, s))
                     // .setTooltip("Hotkey: " + (this.buttons.length + 1))
                     .setClass("srs-review-button")
             );
@@ -285,20 +328,11 @@ export class ReviewAnswerView implements ReviewSubView {
 
         new ButtonComponent(openFileRow)
             .setButtonText("Open File")
-            .onClick(() => {
-                const leaf = view.app.workspace.getUnpinnedLeaf();
-                leaf.setViewState({
-                    type: "markdown",
-                    state: {
-                        file: view.file.path,
-                    },
-                });
-                view.app.workspace.setActiveLeaf(leaf);
-            })
+            .onClick(() => openFile(view))
             .setClass("srs-review-button");
     }
 
-    set(question: string, answer: string, file: TFile) {
+    set(question: string, answer: string, file: TFile, fullContent: string) {
         this.questionEl.empty();
         this.answerEl.empty();
 
@@ -309,6 +343,60 @@ export class ReviewAnswerView implements ReviewSubView {
             null
         );
         MarkdownRenderer.renderMarkdown(answer, this.answerEl, file.path, null);
+    }
+
+    show() {
+        this.containerEl.hidden = false;
+    }
+
+    hide() {
+        this.containerEl.hidden = true;
+    }
+}
+
+export class ReviewSingleSidedView implements ReviewSubView {
+    containerEl: HTMLElement;
+
+    noteEl: HTMLElement;
+    buttons: ButtonComponent[];
+
+    constructor(view: ReviewView) {
+        this.containerEl = view.wrapperEl.createDiv("srs-review-single");
+        this.containerEl.hidden = true;
+
+        this.noteEl = this.containerEl.createDiv("srs-full-note-content");
+
+        let buttonDiv = this.containerEl.createDiv("srs-button-div");
+
+        let buttonRow = buttonDiv.createDiv("srs-flex-row");
+        let openFileRow = buttonDiv.createDiv("srs-flex-row");
+
+        this.buttons = [];
+        view.plugin.algorithm.srsOptions().forEach((s: string) => {
+            this.buttons.push(
+                new ButtonComponent(buttonRow)
+                    .setButtonText(s)
+                    .setCta()
+                    .onClick(() => reviewItem(view, s))
+                    .setClass("srs-review-button")
+            );
+        });
+
+        new ButtonComponent(openFileRow)
+            .setButtonText("Open File")
+            .onClick(() => openFile(view))
+            .setClass("srs-review-button");
+    }
+
+    set(question: string, answer: string, file: TFile, fullContent: string) {
+        this.noteEl.empty();
+
+        MarkdownRenderer.renderMarkdown(
+            fullContent,
+            this.noteEl,
+            file.path,
+            null
+        );
     }
 
     show() {

--- a/src/view.ts
+++ b/src/view.ts
@@ -226,12 +226,34 @@ export class ReviewEmptyView implements ReviewSubView {
     }
 }
 
+function registerLinkClickHandler(el: HTMLElement, view: ReviewView) {
+    el.addEventListener("click", (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+        const anchor = target.closest("a");
+        if (!anchor) return;
+
+        const href = anchor.getAttribute("data-href") || anchor.getAttribute("href");
+        if (!href) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (anchor.classList.contains("internal-link")) {
+            view.app.workspace.openLinkText(href, view.file?.path ?? "", false);
+        } else {
+            window.open(href, "_blank");
+        }
+    });
+}
+
 export class ReviewQuestionView implements ReviewSubView {
     containerEl: HTMLElement;
-
     questionEl: HTMLElement;
+    view: ReviewView;
 
     constructor(view: ReviewView) {
+        this.view = view;
+
         let answerClick = (view: ReviewView) => {
             view.leaf.setViewState({
                 type: REVIEW_VIEW_TYPE,
@@ -247,6 +269,7 @@ export class ReviewQuestionView implements ReviewSubView {
         this.containerEl.hidden = true;
 
         this.questionEl = this.containerEl.createDiv("srs-question-content");
+        registerLinkClickHandler(this.questionEl, view);
 
         let buttonDiv = this.containerEl.createDiv("srs-button-div");
 
@@ -280,7 +303,7 @@ export class ReviewQuestionView implements ReviewSubView {
             "# " + question,
             this.questionEl,
             file.path,
-            null
+            this.view
         );
     }
 
@@ -295,12 +318,13 @@ export class ReviewQuestionView implements ReviewSubView {
 
 export class ReviewAnswerView implements ReviewSubView {
     containerEl: HTMLElement;
-
     questionEl: HTMLElement;
     answerEl: HTMLElement;
     buttons: ButtonComponent[];
+    view: ReviewView;
 
     constructor(view: ReviewView) {
+        this.view = view;
         this.containerEl = view.wrapperEl.createDiv("srs-review-answer");
         this.containerEl.hidden = true;
 
@@ -308,6 +332,7 @@ export class ReviewAnswerView implements ReviewSubView {
 
         this.questionEl = wrapperEl.createDiv("srs-question-content");
         this.answerEl = wrapperEl.createDiv("srs-answer-content");
+        registerLinkClickHandler(wrapperEl, view);
 
         let buttonDiv = this.containerEl.createDiv("srs-button-div");
 
@@ -340,9 +365,9 @@ export class ReviewAnswerView implements ReviewSubView {
             "# " + question,
             this.questionEl,
             file.path,
-            null
+            this.view
         );
-        MarkdownRenderer.renderMarkdown(answer, this.answerEl, file.path, null);
+        MarkdownRenderer.renderMarkdown(answer, this.answerEl, file.path, this.view);
     }
 
     show() {
@@ -356,19 +381,21 @@ export class ReviewAnswerView implements ReviewSubView {
 
 export class ReviewSingleSidedView implements ReviewSubView {
     containerEl: HTMLElement;
-
     noteEl: HTMLElement;
     titleEl: HTMLElement;
     bodyEl: HTMLElement;
     buttons: ButtonComponent[];
+    view: ReviewView;
 
     constructor(view: ReviewView) {
+        this.view = view;
         this.containerEl = view.wrapperEl.createDiv("srs-review-single");
         this.containerEl.hidden = true;
 
         this.noteEl = this.containerEl.createDiv("srs-full-note-content");
         this.titleEl = this.noteEl.createDiv("srs-full-note-title");
         this.bodyEl = this.noteEl.createDiv("srs-full-note-body");
+        registerLinkClickHandler(this.noteEl, view);
 
         let buttonDiv = this.containerEl.createDiv("srs-button-div");
 
@@ -404,7 +431,7 @@ export class ReviewSingleSidedView implements ReviewSubView {
             fullContent,
             this.bodyEl,
             file.path,
-            null
+            this.view
         );
     }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -358,6 +358,8 @@ export class ReviewSingleSidedView implements ReviewSubView {
     containerEl: HTMLElement;
 
     noteEl: HTMLElement;
+    titleEl: HTMLElement;
+    bodyEl: HTMLElement;
     buttons: ButtonComponent[];
 
     constructor(view: ReviewView) {
@@ -365,6 +367,8 @@ export class ReviewSingleSidedView implements ReviewSubView {
         this.containerEl.hidden = true;
 
         this.noteEl = this.containerEl.createDiv("srs-full-note-content");
+        this.titleEl = this.noteEl.createDiv("srs-full-note-title");
+        this.bodyEl = this.noteEl.createDiv("srs-full-note-body");
 
         let buttonDiv = this.containerEl.createDiv("srs-button-div");
 
@@ -389,11 +393,16 @@ export class ReviewSingleSidedView implements ReviewSubView {
     }
 
     set(question: string, answer: string, file: TFile, fullContent: string) {
-        this.noteEl.empty();
+        this.titleEl.empty();
+        this.bodyEl.empty();
+
+        this.titleEl.createEl("h1", {
+            text: file.basename,
+        });
 
         MarkdownRenderer.renderMarkdown(
             fullContent,
-            this.noteEl,
+            this.bodyEl,
             file.path,
             null
         );

--- a/styles.css
+++ b/styles.css
@@ -3,9 +3,9 @@
 }
 
 .srs-qa-wrapper {
-    position: absolute;
-    height: 67%;
-    overflow: auto;
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 20px;
 }
 
 .srs-full-note-content {
@@ -20,18 +20,15 @@
 }
 
 .srs-button-div {
-    position: absolute;
-    bottom: 0;
+    flex-shrink: 0;
     width: 100%;
-
-    height: 33%;
-    max-height: 400px;
     display: flex;
     flex-flow: column wrap;
     justify-content: flex-start;
     align-items: flex-start;
 
     padding-top: 20px;
+    padding-bottom: 20px;
 
     border-top-width: 3px;
     border-top-style: solid;
@@ -48,11 +45,18 @@
 }
 
 .srs-review-wrapper {
-    position: relative;
-    max-width: 700px;
-    min-height: 100%;
-    margin-left: auto;
-    margin-right: auto;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.srs-review-answer,
+.srs-review-question {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
 }
 
 .timings-setting-item {

--- a/styles.css
+++ b/styles.css
@@ -84,3 +84,63 @@
     border-top-style: solid;
     border-top-color: var(--background-modifier-border);
 }
+
+.srs-tracked-modal {
+    width: min(720px, calc(100vw - 40px));
+}
+
+.srs-tracked-summary {
+    color: var(--text-muted);
+    margin-bottom: 12px;
+}
+
+.srs-tracked-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 60vh;
+    overflow: auto;
+}
+
+.srs-tracked-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 0;
+    border-top: 1px solid var(--background-modifier-border);
+}
+
+.srs-tracked-item-main {
+    min-width: 0;
+}
+
+.srs-tracked-title {
+    color: var(--text-normal);
+    font-weight: 600;
+}
+
+.srs-tracked-path {
+    color: var(--text-muted);
+    font-size: var(--font-ui-small);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.srs-tracked-meta {
+    color: var(--text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 4px;
+}
+
+.srs-tracked-due {
+    color: var(--text-accent);
+    font-weight: 600;
+}
+
+.srs-tracked-actions {
+    flex: 0 0 auto;
+}

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,13 @@
     overflow: auto;
 }
 
+.srs-full-note-content {
+    position: absolute;
+    height: 67%;
+    width: 100%;
+    overflow: auto;
+}
+
 .srs-button-div {
     position: absolute;
     bottom: 0;

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,10 @@
     overflow: auto;
 }
 
+.srs-full-note-title h1 {
+    margin-top: 0;
+}
+
 .srs-button-div {
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
Closes #23.

This adds support for single-sided / note-only review mode.

What changed:
- Added a `Single-sided notes` setting.
- When enabled, review shows the full note immediately instead of using the existing question -> answer flow.
- Users can grade memory directly with the existing SRS buttons.
- The note title is shown at the top of the single-sided review view.
- Existing question/answer behavior remains the default.
- Command to list tracked notes.

I tested this locally in Obsidian with a development build.